### PR TITLE
style: hide mobile menu button by default

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -220,7 +220,7 @@
   
   
   .mobile-menu-btn {
-    display: flex;
+    display: none;
     flex-direction: column;
     justify-content: space-between;
     width: 1.5rem;


### PR DESCRIPTION
The mobile menu button should not be visible by default to improve the initial layout and user experience. This change sets `display: none` for the `.mobile-menu-btn` class.